### PR TITLE
fix(infra): correct SonarCloud badges and project configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A comprehensive RESTful Bible API with AI integration, built with Django REST Fr
 
 [![CI](https://github.com/PluraNex/bible-api/workflows/CI/badge.svg)](https://github.com/PluraNex/bible-api/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/PluraNex/bible-api/branch/main/graph/badge.svg)](https://codecov.io/gh/PluraNex/bible-api)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=alert_status)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=security_rating)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=bugs)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=code_smells)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=bible-api_bible-api&metric=ncloc)](https://sonarcloud.io/dashboard?id=bible-api_bible-api)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=bugs)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=PluraNex_bible-api&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=PluraNex_bible-api)
 
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Django](https://img.shields.io/badge/django-4.2+-green.svg)](https://www.djangoproject.com/)

--- a/docs/tasks/2025-09-06--infra--quality-tools-integration.md
+++ b/docs/tasks/2025-09-06--infra--quality-tools-integration.md
@@ -100,5 +100,6 @@ Após a implementação bem-sucedida do T-000 e reorganização da documentaçã
 
 ---
 **Assignee**: @iuryeng  
-**GitHub Issue**: [#TBD]()  
+**GitHub Issue**: [#3](https://github.com/PluraNex/bible-api/issues/3)  
+**GitHub PR**: [#4](https://github.com/PluraNex/bible-api/pull/4)  
 **Epic**: fase-0-boot

--- a/docs/tasks/INDEX.md
+++ b/docs/tasks/INDEX.md
@@ -14,7 +14,7 @@
 | ID | Título | Status | Assignee | Epic | Priority | GitHub Issue | Created |
 |---|---|---|---|---|---|---|---|
 | [T-001](./2025-09-06--api--django-project-setup.md) | Setup Django Project Structure | 🟡 ready | @iuryeng | fase-0-boot | medium | [#TBD]() | 2025-09-06 |
-| [T-002](./2025-09-06--infra--quality-tools-integration.md) | Quality Tools Integration | 🟡 ready | @iuryeng | fase-0-boot | medium | [#TBD]() | 2025-09-06 |
+| [T-002](./2025-09-06--infra--quality-tools-integration.md) | Quality Tools Integration | 🟠 in_review | @iuryeng | fase-0-boot | medium | [#3](https://github.com/PluraNex/bible-api/issues/3) / [PR#4](https://github.com/PluraNex/bible-api/pull/4) | 2025-09-06 |
 
 ## Completed Tasks
 | ID | Título | Status | Assignee | Epic | GitHub Issue | Completed |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=bible-api_bible-api
-sonar.organization=bible-api
+sonar.projectKey=PluraNex_bible-api
+sonar.organization=pluranex
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=Bible API


### PR DESCRIPTION
- Update SonarCloud project key to PluraNex_bible-api
- Fix badge URLs to use correct SonarCloud summary links
- Update sonar-project.properties with correct organization
- Link T-002 task to GitHub issue #3 and PR #4
- Update task status to in_review in INDEX.md

This ensures SonarCloud badges display correctly in README and project analysis works with proper configuration.