### PR TITLE
feat(versions): add Versions API (list/detail) with filters and tests

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,102 @@
+# Gemini Project Context: bible-api
+
+## Project Overview
+
+This project is a comprehensive RESTful Bible API built with the Django REST Framework. It provides access to biblical data, including books, verses, themes, and cross-references. A key feature is its AI integration, which offers agent-based tools for biblical analysis. The project is containerized using Docker, ensuring a consistent development and deployment environment.
+
+### Key Technologies
+
+*   **Backend:** Django, Django REST Framework
+*   **Database:** PostgreSQL
+*   **Caching:** Redis
+*   **Containerization:** Docker, Docker Compose
+*   **Testing:** Pytest
+*   **Linting & Formatting:** Ruff, Black
+
+### Architecture
+
+The project follows a modular architecture, with the core logic organized into Django apps:
+
+*   `bible`: The main application containing the core models and business logic.
+*   `bible.ai`: Handles the AI agent and tool integration.
+*   `bible.apps.auth`: Manages API key authentication.
+*   `config`: Contains the Django project settings and main URL configuration.
+
+## Building and Running
+
+The project uses a `Makefile` to simplify common development tasks.
+
+### Initial Setup
+
+1.  **Clone the repository.**
+2.  **Run the setup script:**
+    ```bash
+    make dev-setup
+    ```
+    This command (defined in the `Makefile`) likely sets up the environment, including creating a `.env` file and building the Docker containers.
+
+### Running the Application
+
+*   **Start all services:**
+    ```bash
+    make up
+    ```
+*   **Stop all services:**
+    ```bash
+    make down
+    ```
+*   **View logs:**
+    ```bash
+    make logs
+    ```
+
+### Running Tests
+
+*   **Run all tests with coverage:**
+    ```bash
+    make test
+    ```
+*   **Run tests without coverage:**
+    ```bash
+    make test-fast
+    ```
+*   **Run all CI checks locally:**
+    ```bash
+    make ci
+    ```
+
+## Development Conventions
+
+### Code Style
+
+*   **Formatting:** The project uses `black` for code formatting and `ruff` for linting and import sorting.
+*   **Linting:** Run `make lint` to check for code quality issues.
+*   **Formatting:** Run `make format` to automatically format the code.
+
+### Testing
+
+*   Tests are written using `pytest` and are located in the `tests/` directory.
+*   The project aims for high test coverage. Run `make coverage` to generate a coverage report.
+
+### Pre-commit Hooks
+
+The project uses pre-commit hooks to enforce code quality standards before committing.
+
+*   **Install hooks:**
+    ```bash
+    pre-commit install
+    ```
+*   **Run hooks on all files:**
+    ```bash
+    pre-commit run --all-files
+    ```
+
+### API Documentation
+
+The API is documented using the OpenAPI standard (Swagger).
+
+*   **View API documentation:** [http://localhost:8000/api/v1/docs/](http://localhost:8000/api/v1/docs/)
+*   **Generate OpenAPI schema:**
+    ```bash
+    make schema
+    ```

--- a/bible/urls.py
+++ b/bible/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("verses/", include(("bible.verses.urls", "verses"), namespace="verses")),
     path("themes/", include(("bible.themes.urls", "themes"), namespace="themes")),
     path("cross-references/", include(("bible.crossrefs.urls", "crossrefs"), namespace="crossrefs")),
+    path("versions/", include(("bible.versions.urls", "versions"), namespace="versions")),
 ]

--- a/bible/versions/serializers.py
+++ b/bible/versions/serializers.py
@@ -1,0 +1,17 @@
+"""Serializers for versions domain."""
+from rest_framework import serializers
+
+from ..models import Version
+
+
+class VersionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Version
+        fields = [
+            "id",
+            "name",
+            "abbreviation",
+            "language",
+            "description",
+            "is_active",
+        ]

--- a/bible/versions/urls.py
+++ b/bible/versions/urls.py
@@ -1,0 +1,11 @@
+"""URL routes for versions domain."""
+from django.urls import path
+
+from . import views
+
+app_name = "versions"
+
+urlpatterns = [
+    path("", views.VersionListView.as_view(), name="versions_list"),
+    path("<str:abbreviation>/", views.VersionDetailView.as_view(), name="version_detail"),
+]

--- a/bible/versions/views.py
+++ b/bible/versions/views.py
@@ -1,0 +1,91 @@
+"""Views for versions domain."""
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework import generics
+
+from ..models import Version
+from .serializers import VersionSerializer
+
+
+class VersionListView(generics.ListAPIView):
+    serializer_class = VersionSerializer
+
+    def get_queryset(self):
+        qs = Version.objects.all().order_by("name")
+        language = self.request.query_params.get("language")
+        if language:
+            qs = qs.filter(language__iexact=language)
+        is_active = self.request.query_params.get("is_active")
+        if is_active is not None:
+            normalized = str(is_active).lower() in {"1", "true", "yes"}
+            qs = qs.filter(is_active=normalized)
+        return qs
+
+    @extend_schema(
+        summary="List Bible versions",
+        tags=["versions"],
+        responses={
+            200: VersionSerializer(many=True),
+            401: {"type": "object", "properties": {"detail": {"type": "string"}}},
+        },
+        examples=[
+            OpenApiExample(
+                "List versions",
+                value={
+                    "count": 2,
+                    "next": None,
+                    "previous": None,
+                    "results": [
+                        {
+                            "id": 1,
+                            "name": "King James Version",
+                            "abbreviation": "KJV",
+                            "language": "en",
+                            "description": "Classic English translation",
+                            "is_active": True,
+                        },
+                        {
+                            "id": 2,
+                            "name": "Nova Versão Internacional",
+                            "abbreviation": "NVI",
+                            "language": "pt",
+                            "description": "Tradução em português",
+                            "is_active": True,
+                        },
+                    ],
+                },
+            )
+        ],
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+
+class VersionDetailView(generics.RetrieveAPIView):
+    queryset = Version.objects.all()
+    serializer_class = VersionSerializer
+    lookup_field = "abbreviation"
+
+    @extend_schema(
+        summary="Get version by abbreviation",
+        tags=["versions"],
+        responses={
+            200: VersionSerializer,
+            401: {"type": "object", "properties": {"detail": {"type": "string"}}},
+            404: {"type": "object", "properties": {"detail": {"type": "string"}}},
+        },
+        examples=[
+            OpenApiExample(
+                "Version detail",
+                value={
+                    "id": 1,
+                    "name": "King James Version",
+                    "abbreviation": "KJV",
+                    "language": "en",
+                    "description": "Classic English translation",
+                    "is_active": True,
+                },
+            )
+        ],
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)

--- a/docs/tasks/2025-09-07--api--architecture-alignment-refactor.md
+++ b/docs/tasks/2025-09-07--api--architecture-alignment-refactor.md
@@ -1,0 +1,70 @@
+---
+id: T-001
+title: "[api] Refatoração para Alinhamento Arquitetural"
+status: backlog
+created: 2025-09-07
+updated: 2025-09-07
+owner: "@gemini"
+reviewers: ["@IuryAlves"]
+labels: ["area/api", "type/refactor"]
+priority: high
+effort: L
+risk: medium
+depends_on: []
+related: ["docs/architecture/BIBLE_API_BASE_PROJECT.md"]
+epic: "Fundação da API"
+branch: "refactor/architecture-alignment"
+pr: ""
+github_issue: ""
+due: null
+---
+
+## Contexto
+A implementação atual da API, embora funcional, diverge da arquitetura de referência documentada em `docs/architecture/BIBLE_API_BASE_PROJECT.md`. Para garantir a escalabilidade, manutenibilidade e consistência do projeto, é necessário refatorar a estrutura atual para alinhá-la com a visão arquitetural.
+
+## Objetivo e Critérios de Aceite
+O objetivo desta tarefa é reestruturar o projeto para seguir o padrão DDD-like proposto, com separação clara de domínios e camadas de serviço.
+
+- [ ] **CA1:** Os domínios (`books`, `verses`, `themes`, etc.) devem ser refatorados para apps Django independentes dentro de `bible/apps/`.
+- [ ] **CA2:** A lógica de negócio deve ser extraída das views e movida para uma camada de `services` e `selectors`.
+- [ ] **CA3:** A estrutura de URLs deve ser expandida para incluir os endpoints detalhados na documentação de arquitetura.
+- [ ] **CA4:** Os modelos devem ser atualizados e expandidos para refletir a estrutura proposta na documentação.
+- [ ] **CA5:** As configurações do projeto (`settings.py`) devem ser atualizadas para incluir as configurações avançadas de cache, CORS e logging.
+
+## Escopo / Fora do Escopo
+- **Inclui:** Refatoração da estrutura de diretórios, criação de apps Django para cada domínio, implementação da camada de serviço, expansão das URLs e modelos.
+- **Não inclui:** Implementação de todas as funcionalidades de negócio para todos os endpoints. O foco é na estrutura e no alinhamento arquitetural.
+
+## Impacto Técnico
+**Contrato (OpenAPI)**: Haverá mudanças significativas nas URLs e na estrutura dos dados de resposta.
+**DB/Migrations**: Serão necessárias novas migrações para refletir as mudanças nos modelos.
+**Throttle/Cache**: As políticas de throttle e cache serão implementadas conforme a documentação.
+**Performance**: A introdução da camada de serviço pode ter um pequeno impacto na performance, que deve ser monitorado.
+**Segurança**: As permissões e escopos de API serão revisados e aplicados de forma mais granular.
+
+## Plano de Testes
+**API**: Todos os endpoints existentes devem continuar funcionando após a refatoração. Novos testes devem ser criados para os novos endpoints.
+**Contrato**: O schema OpenAPI deve ser atualizado para refletir as novas URLs e estruturas de dados.
+**Dados**: As migrações de banco de dados devem ser testadas para garantir que não haja perda de dados.
+
+## Observabilidade
+- Métricas de performance devem ser monitoradas para identificar qualquer regressão.
+- Logs devem ser configurados para fornecer visibilidade sobre a nova camada de serviço.
+
+## Rollout & Rollback
+- A refatoração será implementada em um branch separado.
+- A reversão pode ser feita descartando o branch de refatoração.
+
+## Checklist Operacional (Autor)
+- [ ] OpenAPI gerado/commitado em `docs/`
+- [ ] `make fmt lint test` ok local
+- [ ] CI verde
+- [ ] PR descreve impacto e rollback
+
+## Checklist Operacional (Revisor)
+- [ ] Contrato estável ou depreciação formal
+- [ ] Testes suficientes
+- [ ] Sem N+1; p95 dentro do orçamento
+- [ ] Migrations pequenas e reversíveis
+- [ ] Segurança: sem PII em logs; escopos e rate adequados
+- [ ] Cache/invalidação documentados

--- a/tests/api/bible/versions/test_versions_endpoints.py
+++ b/tests/api/bible/versions/test_versions_endpoints.py
@@ -1,0 +1,45 @@
+"""
+API tests for versions endpoints.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from bible.models import APIKey, Version
+
+
+class VersionsApiTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="vers_user")
+        self.api_key = APIKey.objects.create(name="Vers Key", user=self.user, scopes=["read"])
+        Version.objects.create(name="King James Version", abbreviation="KJV", language="en", is_active=True)
+        Version.objects.create(name="Nova Versão Internacional", abbreviation="NVI", language="pt", is_active=True)
+        Version.objects.create(name="Outdated Version", abbreviation="OV", language="en", is_active=False)
+
+    def test_requires_auth(self):
+        self.assertEqual(self.client.get("/api/v1/bible/versions/").status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_versions(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(resp.json().get("results", [])), 2)
+
+    def test_filter_by_language_and_active(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/?language=en&is_active=true")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        items = resp.json().get("results", [])
+        self.assertTrue(all(v["language"].lower() == "en" for v in items))
+        self.assertTrue(all(v["is_active"] is True for v in items))
+
+    def test_detail_and_404(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        ok = self.client.get("/api/v1/bible/versions/KJV/")
+        self.assertEqual(ok.status_code, status.HTTP_200_OK)
+        self.assertEqual(ok.json()["abbreviation"], "KJV")
+
+        miss = self.client.get("/api/v1/bible/versions/FAKE/")
+        self.assertEqual(miss.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
### Contexto
Implementa T-007 (Versions API) conforme arquitetura base. Fornece endpoints para listar e detalhar traduções bíblicas (KJV, NVI, etc.), com filtros simples e paginação.

### O que foi implementado
*   **Endpoints (protegidos por Api-Key):**
    *   `GET /api/v1/bible/versions/` (lista com paginação; filtros `language` e `is_active`; ordering por `name`)
    *   `GET /api/v1/bible/versions/<abbreviation>/` (detalhe por `abbreviation`)
*   **Código:**
    *   `bible/versions/serializers.py` (`VersionSerializer`)
    *   `bible/versions/views.py` (`VersionListView`, `VersionDetailView`)
    *   `bible/versions/urls.py` e `include` em `bible/urls.py`
*   **OpenAPI:**
    *   `@extend_schema` com tags `[versions]`, responses `200/401/404` e exemplos
*   **Testes:**
    *   `tests/api/bible/versions/test_versions_endpoints.py` (401/200/404 + filtros)

### Critérios de Aceite (T-007)
- [x] CA1 — `GET /api/v1/bible/versions/`
- [x] CA2 — `GET /api/v1/bible/versions/<abbreviation>/`
- [x] CA3 — Filtros `language` e `is_active`
- [x] CA4 — Paginação padrão
- [x] CA5 — Ordering por `name`
- [x] CA6 — Serializer com campos essenciais
- [x] CA7 — Api-Key auth
- [x] CA8 — Testes (auth/list/detail/filtros)
- [x] CA9 — OpenAPI anotado
- [x] CA10 — URLs por domínio + namespace

### Como testar
1.  Sem credencial → `401 Unauthorized`
2.  Com `Api-Key` válida → `200 OK`
3.  Filtros: `?language=en`, `?is_active=true`

### Rollout & Rollback
*   **Rollout:** Sem migrations; merge seguro.
*   **Rollback:** Revert do PR.

---
*Closes: N/A (task local: `docs/tasks/2025-09-07--api--versions-api-implementation.md`)*