### PR TITLE
feat(auth): implement HasAPIScopes permission class with scope valida…

### DIFF
--- a/bible/apps/auth/permissions.py
+++ b/bible/apps/auth/permissions.py
@@ -1,0 +1,58 @@
+"""
+Permission classes for Bible API.
+"""
+from rest_framework import permissions
+
+from bible.models import APIKey
+
+
+class HasAPIScopes(permissions.BasePermission):
+    """
+    Permission class that checks if the authenticated API key has required scopes.
+
+    Usage:
+        class MyView(APIView):
+            permission_classes = [HasAPIScopes]
+            required_scopes = ['read']  # or ['write', 'admin']
+
+    Scopes:
+        - 'read': Basic read access to biblical data
+        - 'write': Create/update access (bookmarks, notes)
+        - 'admin': Administrative access
+        - 'ai': AI/LLM integration features
+        - 'audio': Text-to-speech synthesis
+    """
+
+    def has_permission(self, request, view):
+        """
+        Check if the request has permission based on required scopes.
+        """
+        # Allow unauthenticated requests if no scopes required
+        required_scopes = getattr(view, "required_scopes", [])
+        if not required_scopes:
+            return True
+
+        # Check if user is authenticated with API key
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Get the API key from auth
+        if not hasattr(request, "auth") or not isinstance(request.auth, APIKey):
+            return False
+
+        api_key = request.auth
+
+        # Check if API key has all required scopes
+        for scope in required_scopes:
+            if not api_key.has_scope(scope):
+                return False
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check object-level permissions.
+        For now, use the same logic as has_permission.
+        Can be extended for object-specific scope checking.
+        """
+        return self.has_permission(request, view)

--- a/bible/versions/views.py
+++ b/bible/versions/views.py
@@ -2,12 +2,15 @@
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework import generics
 
+from ..apps.auth.permissions import HasAPIScopes
 from ..models import Version
 from .serializers import VersionSerializer
 
 
 class VersionListView(generics.ListAPIView):
     serializer_class = VersionSerializer
+    permission_classes = [HasAPIScopes]
+    required_scopes = ["read"]
 
     def get_queryset(self):
         qs = Version.objects.all().order_by("name")
@@ -63,7 +66,13 @@ class VersionListView(generics.ListAPIView):
 class VersionDetailView(generics.RetrieveAPIView):
     queryset = Version.objects.all()
     serializer_class = VersionSerializer
-    lookup_field = "abbreviation"
+    permission_classes = [HasAPIScopes]
+    required_scopes = ["read"]
+
+    def get_object(self):
+        """Get version by abbreviation (case-insensitive)."""
+        abbreviation = self.kwargs["abbreviation"]
+        return generics.get_object_or_404(self.get_queryset(), abbreviation__iexact=abbreviation)
 
     @extend_schema(
         summary="Get version by abbreviation",

--- a/docs/architecture/BIBLE_API_BASE_PROJECT.md
+++ b/docs/architecture/BIBLE_API_BASE_PROJECT.md
@@ -85,8 +85,9 @@ urlpatterns = [
 
     # 📖 VERSIONS
     path("versions/", include([
+        path("", views.VersionListView.as_view(), name="versions_list"),
+        path("<str:abbreviation>/", views.VersionDetailView.as_view(), name="version_detail"),
         path("by-language/<str:language_code>/", views.VersionsByLanguageView.as_view(), name="versions_by_language"),
-        path("<int:version_id>/detail/", views.VersionDetailView.as_view(), name="version_detail"),
         path("comparison/<str:reference>/", views.VersionComparisonView.as_view(), name="version_comparison"),
         path("language-comparison/<str:reference>/", views.LanguageComparisonView.as_view(), name="language_comparison"),
     ])),

--- a/tests/api/bible/auth/__init__.py
+++ b/tests/api/bible/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Bible API authentication."""

--- a/tests/api/bible/auth/test_permissions.py
+++ b/tests/api/bible/auth/test_permissions.py
@@ -1,0 +1,166 @@
+"""
+Tests for authentication and permissions.
+"""
+from unittest.mock import Mock
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APITestCase
+
+from bible.apps.auth.permissions import HasAPIScopes
+from bible.models import APIKey
+
+
+class HasAPIScopesTest(TestCase):
+    """Test HasAPIScopes permission class."""
+
+    def setUp(self):
+        self.permission = HasAPIScopes()
+        self.user = User.objects.create_user(username="testuser")
+        self.api_key = APIKey.objects.create(name="Test Key", user=self.user, scopes=["read", "write"])
+
+    def test_no_required_scopes_allows_access(self):
+        """Test that views with no required_scopes allow access."""
+        request = Mock()
+        request.user = self.user
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = []
+
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_unauthenticated_user_denied_with_scopes(self):
+        """Test that unauthenticated users are denied when scopes required."""
+        request = Mock()
+        request.user = None
+
+        view = Mock()
+        view.required_scopes = ["read"]
+
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    def test_authenticated_user_without_api_key_denied(self):
+        """Test that user without API key is denied."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = None
+
+        view = Mock()
+        view.required_scopes = ["read"]
+
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    def test_api_key_with_required_scope_allowed(self):
+        """Test that API key with required scope is allowed."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = ["read"]
+
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_api_key_missing_required_scope_denied(self):
+        """Test that API key missing required scope is denied."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = ["admin"]  # api_key only has 'read', 'write'
+
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    def test_api_key_with_multiple_required_scopes_allowed(self):
+        """Test that API key with all required scopes is allowed."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = ["read", "write"]
+
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_api_key_missing_one_of_multiple_scopes_denied(self):
+        """Test that API key missing one of multiple required scopes is denied."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = ["read", "write", "admin"]
+
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    def test_object_permission_delegates_to_has_permission(self):
+        """Test that object permission uses same logic as has_permission."""
+        request = Mock()
+        request.user = self.user
+        request.user.is_authenticated = True
+        request.auth = self.api_key
+
+        view = Mock()
+        view.required_scopes = ["read"]
+
+        obj = Mock()
+
+        # Should return same result as has_permission
+        has_perm = self.permission.has_permission(request, view)
+        has_obj_perm = self.permission.has_object_permission(request, view, obj)
+
+        self.assertEqual(has_perm, has_obj_perm)
+
+
+class VersionsEndpointsPermissionIntegrationTest(APITestCase):
+    """Integration tests for versions endpoints with HasAPIScopes."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser")
+
+    def test_versions_list_without_api_key_denied(self):
+        """Test that versions list requires API key."""
+        response = self.client.get("/api/v1/bible/versions/")
+        self.assertEqual(response.status_code, 401)
+        # Verify WWW-Authenticate header is present
+        self.assertIn("WWW-Authenticate", response.headers)
+        self.assertEqual(response.headers["WWW-Authenticate"], "Api-Key")
+
+    def test_versions_list_with_read_scope_allowed(self):
+        """Test that versions list works with read scope."""
+        api_key = APIKey.objects.create(name="Test Key", user=self.user, scopes=["read"])
+
+        response = self.client.get("/api/v1/bible/versions/", HTTP_AUTHORIZATION=f"Api-Key {api_key.key}")
+        self.assertEqual(response.status_code, 200)
+
+    def test_versions_list_without_read_scope_denied(self):
+        """Test that versions list denied without read scope."""
+        api_key = APIKey.objects.create(name="Test Key", user=self.user, scopes=["write"])  # Missing 'read' scope
+
+        response = self.client.get("/api/v1/bible/versions/", HTTP_AUTHORIZATION=f"Api-Key {api_key.key}")
+        self.assertEqual(response.status_code, 403)
+
+    def test_version_detail_without_read_scope_denied(self):
+        """Test that version detail denied without read scope."""
+        api_key = APIKey.objects.create(name="Test Key", user=self.user, scopes=["write"])  # Missing 'read' scope
+
+        response = self.client.get("/api/v1/bible/versions/KJV/", HTTP_AUTHORIZATION=f"Api-Key {api_key.key}")
+        self.assertEqual(response.status_code, 403)
+
+    def test_version_detail_with_read_scope_allowed(self):
+        """Test that version detail works with read scope."""
+        # Note: This test will fail until we have actual Version objects
+        # but it tests the permission logic
+        api_key = APIKey.objects.create(name="Test Key", user=self.user, scopes=["read"])
+
+        response = self.client.get("/api/v1/bible/versions/KJV/", HTTP_AUTHORIZATION=f"Api-Key {api_key.key}")
+        # Expecting 404 (not found) rather than 403 (forbidden)
+        # which means permission passed but object doesn't exist
+        self.assertIn(response.status_code, [200, 404])

--- a/tests/api/bible/versions/test_versions_endpoints.py
+++ b/tests/api/bible/versions/test_versions_endpoints.py
@@ -43,3 +43,61 @@ class VersionsApiTest(TestCase):
 
         miss = self.client.get("/api/v1/bible/versions/FAKE/")
         self.assertEqual(miss.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_detail_abbreviation_case_insensitive(self):
+        """Detail lookup by abbreviation should be case-insensitive."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/kjv/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.json()["abbreviation"], "KJV")
+
+    def test_list_ordering_by_name(self):
+        """List should be ordered deterministically by name (asc)."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        names = [item["name"] for item in resp.json().get("results", [])]
+        self.assertEqual(names, sorted(names))
+
+    def test_filter_is_active_false(self):
+        """Filtering by is_active=false should return only inactive versions."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/?is_active=false")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        items = resp.json().get("results", [])
+        self.assertGreaterEqual(len(items), 1)
+        self.assertTrue(all(item["is_active"] is False for item in items))
+
+    def test_language_filter_case_insensitive(self):
+        """Language filter should be case-insensitive."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+        resp = self.client.get("/api/v1/bible/versions/?language=EN")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        items = resp.json().get("results", [])
+        self.assertTrue(all(v["language"].lower() == "en" for v in items))
+
+    def test_is_active_various_formats(self):
+        """is_active should accept various boolean formats."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {self.api_key.key}")
+
+        # Test different true formats
+        for true_val in ["1", "true", "True", "TRUE", "yes", "YES"]:
+            resp = self.client.get(f"/api/v1/bible/versions/?is_active={true_val}")
+            self.assertEqual(resp.status_code, status.HTTP_200_OK)
+            items = resp.json().get("results", [])
+            if items:  # Only check if we have results
+                self.assertTrue(all(item["is_active"] is True for item in items))
+
+    def test_requires_read_scope(self):
+        """Endpoints should require 'read' scope."""
+        # API key without 'read' scope
+        no_read_key = APIKey.objects.create(name="No Read Key", user=self.user, scopes=["write"])  # Missing 'read'
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Api-Key {no_read_key.key}")
+
+        # Both endpoints should return 403
+        list_resp = self.client.get("/api/v1/bible/versions/")
+        self.assertEqual(list_resp.status_code, status.HTTP_403_FORBIDDEN)
+
+        detail_resp = self.client.get("/api/v1/bible/versions/KJV/")
+        self.assertEqual(detail_resp.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
- Add HasAPIScopes permission class for granular API access control
- Support for 'read', 'write', 'admin', 'ai', 'audio' scopes
- Apply to versions endpoints with 'read' scope requirement
- Enhance versions detail lookup with case-insensitive abbreviation search
- Add comprehensive test coverage for permission validation and edge cases
- Update architecture blueprint to reflect design decisions

🤖 Generated with [Claude Code](https://claude.ai/code)


Authored-By: iuryeng <iuryfernandes.eng@gmail.com>